### PR TITLE
[Fix]退会処理が正常に行われていなかった問題を修正 #117

### DIFF
--- a/app/controllers/public/omniauth_callbacks_controller.rb
+++ b/app/controllers/public/omniauth_callbacks_controller.rb
@@ -19,9 +19,12 @@ class Public::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def authorization(provider)
     @user = User.from_omniauth(request.env["omniauth.auth"])
 
-    if @user.persisted?
+    if (@user.persisted?) && (@user.is_active == true)
       sign_in_and_redirect @user, event: :authentication
       flash[:notice] = "#{provider}アカウントによる認証に成功しました。"
+    elsif (@user.persisted?) && (@user.is_active == false)
+      flash[:error] = "退会済みです"
+      redirect_to new_user_registration_path
     else
       session["devise.google_data"] = request.env["omniauth.auth"][:info]
       flash[:error] = "会員登録をしてください"

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -2,7 +2,7 @@ class Public::UsersController < ApplicationController
   skip_before_action :authenticate_admin!
   include CommonActions
   before_action :set_genres, except: [:confirm, :widhdraw]
-  before_action :set_user_profile, except: [:index, :confirm, :widhdraw]
+  before_action :set_user_profile, except: [:index, :confirm, :withdraw]
 
   def index
     @user_profile = User.find(params[:user_id])


### PR DESCRIPTION
usersコントローラのbefore_actionの範囲指定ミスを修正。
退会処理をしてもSNSログインができてしまっていた問題を修正。